### PR TITLE
Add support disclaimer for 5eTools

### DIFF
--- a/server/public/js/controllers/exportBestiary.js
+++ b/server/public/js/controllers/exportBestiary.js
@@ -14,7 +14,7 @@ var exportBestiaryCtrl = function ($scope, bestiary, $mdDialog, $mdToast, DataAd
             name: "5E Tools",
             fileSuffix: "_(5e_tools)",
             fileExtension: "json",
-            description: '<a href="https://5e.tools/">5E Tools</a> has a browseable collection of official 5E information, including core rules, monsters, and more. Additionally, creatures in the 5E Tools format can be imported into the Roll20 virtual tabletop.',
+            description: '<a href="https://5e.tools/">5E Tools</a> has a browseable collection of official 5E information, including core rules, monsters, and more. Additionally, creatures in the 5E Tools format can be imported into the Roll20 virtual tabletop.<br>Please note that support for this export tool is not provided by 5eTools and any queries or issues should be directed to <a href="https://github.com/haswellr/CritterDB">CritterDB</a>.',
             adapterFormat: DataAdapter.Format["5E_TOOLS_BESTIARY"]
         }
     }

--- a/server/public/js/controllers/exportCreatureJson.js
+++ b/server/public/js/controllers/exportCreatureJson.js
@@ -14,7 +14,7 @@ var exportCreatureJsonCtrl = function ($scope, creature, $mdDialog, $mdToast, Da
             name: "5E Tools",
             fileSuffix: "_(5e_tools)",
             fileExtension: "json",
-            description: '<a href="https://5e.tools/">5E Tools</a> has a browseable collection of official 5E information, including core rules, monsters, and more. Additionally, creatures in the 5E Tools format can be imported into the Roll20 virtual tabletop.',
+            description: '<a href="https://5e.tools/">5E Tools</a> has a browseable collection of official 5E information, including core rules, monsters, and more. Additionally, creatures in the 5E Tools format can be imported into the Roll20 virtual tabletop.<br>Please note that support for this export tool is not provided by 5eTools and any queries or issues should be directed to <a href="https://github.com/haswellr/CritterDB">CritterDB</a>.',
             adapterFormat: DataAdapter.Format["5E_TOOLS_CREATURE"]
         }
     }


### PR DESCRIPTION
Great to see more tools popping up that support the 5eTools dataset, but we can't hold the support burden for all of them.
You might also consider taking a second look at the exporter and trying to get it more compliant with the up to date data schema: https://github.com/TheGiddyLimit/homebrew/blob/master/_schema/bestiary/bestiary.json

A random export presented a number of issues:
![image](https://user-images.githubusercontent.com/52298102/176995724-83f5c837-e58f-4ea7-99c0-ffa2a8c9e2e6.png)
